### PR TITLE
[ci] sync template files

### DIFF
--- a/manifest/deployment.yaml
+++ b/manifest/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: starlight-view-modes
-  namespace: starlight-view-modes
+  name: <%= repositoryName %>
+  namespace: <%= repositoryName %>
   labels:
-    app: starlight-view-modes
+    app: <%= repositoryName %>
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: starlight-view-modes
+      app: <%= repositoryName %>
   template:
     metadata:
       labels:
-        app: starlight-view-modes
+        app: <%= repositoryName %>
     spec:
       containers:
-        - name: starlight-view-modes
-          image: "trueberryless/starlight-view-modes"
+        - name: <%= repositoryName %>
+          image: "trueberryless/<%= repositoryName %>"
           imagePullPolicy: Always


### PR DESCRIPTION
This PR syncs the specified GitHub template files from the [central repository](https://github.com/trueberryless-org/template-files).

### Changes:
- add special handling for deployment file - ([60e9260](https://github.com/trueberryless-org/template-files/commit/60e9260319a3aedf272e689bc7fd20e83748bdf6))