### PR TITLE
Update ZenMode.astro

### DIFF
--- a/packages/starlight-view-modes/routes/ZenMode.astro
+++ b/packages/starlight-view-modes/routes/ZenMode.astro
@@ -80,7 +80,7 @@ if (image) {
       frontmatter={{
         ...(remarkPluginFrontmatter as any),
         pagefind: false,
-        title: entry.data.title
+        title: entry.data.title,
       }}
       headings={headings}
       hasSidebar={hasSidebar}
@@ -99,7 +99,7 @@ if (image) {
     <StarlightPage
       frontmatter={{
         ...(remarkPluginFrontmatter as any),
-        
+
         hero: {
           ...remarkPluginFrontmatter.hero,
           image: {


### PR DESCRIPTION

#### Description

in starlight  0.34.7 without this line it will give an error when hovering over the zen mode icon




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the page title is correctly included and displayed in Zen Mode across all image scenarios — no images, dark-only, dark+light, and when raw image HTML is used — so titles now appear consistently on Zen Mode pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->